### PR TITLE
fix: get version from tf module json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Local .terraform directories
 **/.terraform/*
 
+# .terraform.lock
+.terraform.lock.hcl
+
 # .tfstate files
 *.tfstate
 *.tfstate.*

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   name = "fullstory-cloud-relay/aws"
 
-  version           = compact([for m in jsondecode(file("${path.module}/../modules.json"))["Modules"] : length(regexall(".${local.name}.*", m["Source"])) > 0 ? m["Version"] : ""])[0]
+  version           = try(compact([for m in jsondecode(file("${path.module}/../modules.json"))["Modules"] : length(regexall(".${local.name}.*", m["Source"])) > 0 ? m["Version"] : ""])[0], "unreleased")
   create_dns_record = tobool(var.route53_zone_name != null)
   endpoints = {
     edge : "edge.${var.target_fqdn}",

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,9 @@
 locals {
-  version           = "0.1.0" #TODO: Dynamically inject?
+  version = compact([for m in jsondecode(file("${path.module}/../modules.json"))["Modules"] : length(regexall(".*fullstory-cloud-relay.*", m["Source"])) > 0 ? m["Version"] : ""])[0]
+
+
   create_dns_record = tobool(var.route53_zone_name != null)
-  endpoints         = {
+  endpoints = {
     edge : "edge.${var.target_fqdn}",
     rs : "rs.${var.target_fqdn}",
     services : "services.fullstory.com"

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   name = "fullstory-cloud-relay/aws"
 
-  version           = compact([for m in jsondecode(file("${path.module}/../modules.json"))["Modules"] : length(regexall(".${name}.*", m["Source"])) > 0 ? m["Version"] : ""])[0]
+  version           = compact([for m in jsondecode(file("${path.module}/../modules.json"))["Modules"] : length(regexall(".${local.name}.*", m["Source"])) > 0 ? m["Version"] : ""])[0]
   create_dns_record = tobool(var.route53_zone_name != null)
   endpoints = {
     edge : "edge.${var.target_fqdn}",

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
-  name = "fullstory-cloud-relay/aws"
+  module_name = "fullstory-cloud-relay/aws"
 
-  version           = try(compact([for m in jsondecode(file("${path.module}/../modules.json"))["Modules"] : length(regexall(".${local.name}.*", m["Source"])) > 0 ? m["Version"] : ""])[0], "unreleased")
+  version           = try(compact([for m in jsondecode(file("${path.module}/../modules.json"))["Modules"] : length(regexall(".${local.module_name}.*", m["Source"])) > 0 ? m["Version"] : ""])[0], "unreleased")
   create_dns_record = tobool(var.route53_zone_name != null)
   endpoints = {
     edge : "edge.${var.target_fqdn}",

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
-  version = compact([for m in jsondecode(file("${path.module}/../modules.json"))["Modules"] : length(regexall(".*fullstory-cloud-relay.*", m["Source"])) > 0 ? m["Version"] : ""])[0]
+  name = "fullstory-cloud-relay/aws"
 
-
+  version           = compact([for m in jsondecode(file("${path.module}/../modules.json"))["Modules"] : length(regexall(".${name}.*", m["Source"])) > 0 ? m["Version"] : ""])[0]
   create_dns_record = tobool(var.route53_zone_name != null)
   endpoints = {
     edge : "edge.${var.target_fqdn}",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Are these changes a new behavior? What was the old vs new -->
Dynamically inject module version from `terraform init`'s downloaded modules.json file. That file looks somewhat like:
```
{"Modules":[{"Key":"fullstory_relay","Source":"registry.terraform.io/fullstorydev/fullstory-cloud-relay/aws","Version":"0.1.0","Dir":".terraform/modules/fullstory_relay"},{"Key":"","Source":"","Dir":"."}]}
```

## Issue or Ticket
<!--- There should be an issue (github issue) or Jira ticket for this work -->

<!--- Please link to the issue here: -->
n/a


<!-- Comment this out if you'd like to include more information for an easier review
## Additional Info
 -->


## Checklist before submitting PR for review
- [x] I have tested these changes with the included tfvars
- [ ] This change requires a doc update, and I've included it
- [x] My code follows the style guidelines of this project
- [x] I have ensured my code is commented and any new terraform variables have proper descriptions
