### PR TITLE
fix: extracting ACM certificate from the module for relays without r53 zone. Also, updating distribuions settings

### DIFF
--- a/.terraform-docs.yaml
+++ b/.terraform-docs.yaml
@@ -27,29 +27,40 @@ content: |-
   
   ### Without Route 53 Record Creation
   
-  By default, the module will not create a DNS record in Route 53. An example of which is below.
+  By default, the module will not create a DNS record in Route 53 or certificate in ACM.
+  
+  A certificate must be created and validated before the relay can be created. This can be done manually or via Terraform (example below).
+  
+  ```hcl
+  {{ include "examples/without_route_53/cert.tf" }}
+  ```
+  
+  Once the certificate is created, it must be validated before it can be used. The DNS validation information can be extracted from the Terraform state using the command below.
+  
+  ```bash
+  terraform output relay_cert_dns_validation
+  ```
+  
+  Create a DNS validation `CNAME` record that routes the `relay_cert_dns_validation.<relay_fqdn>.name` to the `relay_cert_dns_validation.<relay_fqdn>.record` value.
+  Once the DNS record has been created, the certificate can take up to 15 minutes to become active. The status can be checked using the command below.
+  
+  ```bash
+  aws acm list-certificates --query "CertificateSummaryList[?DomainName=='<relay_fqdn>'].Status" 
+  ```
+  
+  Now that the certificate has been created and is active, the ARN can be passed into the module as seen below.
   
   ```hcl
   {{ include "examples/without_route_53/main.tf" }}
   ```
   
-  Once the resources have been successfully created, the CNAME of the CloudFront distribution and the DNS validation record information can be extracted from the Terraform state using the command below.
+  Once the resources have been successfully created, the final step is to create the CNAME of the CloudFront distribution which can be extracted from the Terraform state using the command below.
   
   ```bash
-  terraform output relay_ip_address
+  terraform output relay_distribution_domain_name
   ```
   
-  If the above command does not work, ensure that the two `output` blocks are present as shown in the example above.
-  
-  Next, create a `CNAME` DNS record that routes the `relay_fqdn` to the `relay_distribution_domain_name` found in the previous command.
-  
-  Finally, create a DNS validation `CNAME` record that routes the `relay_cert_dns_validation.<relay_fqdn>.name` to the `relay_cert_dns_validation.<relay_fqdn>.record` value.
-  
-  Once the DNS record has been created, the SSL certificate can take up to 15 minutes to become active. The status can be checked using the command below.
-  
-  ```bash
-  aws acm list-certificates
-  ```
+  Create a `CNAME` DNS record that routes the `relay_fqdn` to the `relay_distribution_domain_name` found in the previous command.
   
   ### European Realm Target
   

--- a/examples/without_route_53/cert.tf
+++ b/examples/without_route_53/cert.tf
@@ -1,0 +1,15 @@
+resource "aws_acm_certificate" "fullstory_relay" {
+  domain_name       = "fsrelay.your-company.com"
+  validation_method = "DNS"
+}
+
+output "relay_cert_dns_validation" {
+  description = "The information required to create a DNS validation record."
+  value       = {
+    for dvo in aws_acm_certificate.fullstory_relay.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+}

--- a/examples/without_route_53/main.tf
+++ b/examples/without_route_53/main.tf
@@ -1,12 +1,9 @@
 module "fullstory_relay" {
-  source     = "fullstorydev/fullstory-cloud-relay/aws"
-  relay_fqdn = "fsrelay.your-company.com"
+  source              = "fullstorydev/fullstory-cloud-relay/aws"
+  relay_fqdn          = "fsrelay.your-company.com"
+  acm_certificate_arn = aws_acm_certificate.fullstory_relay.arn
 }
 
 output "relay_distribution_domain_name" {
   value = module.fullstory_relay.relay_distribution_domain_name
-}
-
-output "relay_cert_dns_validation" {
-  value = module.fullstory_relay.relay_cert_dns_validation
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,14 +2,3 @@ output "relay_distribution_domain_name" {
   description = "The domain name of the relay CloudFront distribution."
   value       = aws_cloudfront_distribution.fullstory_relay.domain_name
 }
-
-output "relay_cert_dns_validation" {
-  description = "The information required to create a DNS validation record."
-  value       = {
-    for dvo in aws_acm_certificate.fullstory_relay.domain_validation_options : dvo.domain_name => {
-      name   = dvo.resource_record_name
-      record = dvo.resource_record_value
-      type   = dvo.resource_record_type
-    }
-  }
-}

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,12 @@ variable "target_fqdn" {
 
 variable "route53_zone_name" {
   type        = string
-  description = "(optional) The Route 53 zone name for placing the DNS CNAME record. Defaults to null."
+  description = "(optional) The Route 53 zone name for placing the DNS CNAME record. If omitted, a value for `acm_certificate_arn` must be provided. Defaults to null."
+  default     = null
+}
+
+variable "acm_certificate_arn" {
+  type        = string
+  description = "(optional) The ARN of the ACM certificate to be used for the relay. If omitted, a value for `route53_zone_name` must be provided. Defaults to null."
   default     = null
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Are these changes a new behavior? What was the old vs new -->

The goal of this PR is two-fold:
1. Sync the distribution settings to match those in the test distribution created by @tsimms 
2. Extract the ACM certificate creation out of the module in the `without_route_53` scenario. This was necessary as the certificate requires manual validation and the distribution will fail to create until this is done. The README has been updated to include this information about the steps required to manually create and validate the ACM certificate.


## Issue or Ticket
<!--- There should be an issue (github issue) or Jira ticket for this work -->

<!--- Please link to the issue here: -->


<!-- Comment this out if you'd like to include more information for an easier review
## Additional Info
 -->


## Checklist before submitting PR for review
- [x] I have tested these changes with the included tfvars
- [x] This change requires a doc update, and I've included it
- [x] My code follows the style guidelines of this project
- [x] I have ensured my code is commented and any new terraform variables have proper descriptions
