### PR TITLE
ci: Remove Github plugin from automated semantic-release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
               echo $DEPLOY_KEY | base64 -d > /tmp/deploy_key
               chmod 600 /tmp/deploy_key
               ssh-add /tmp/deploy_key </dev/null
-              npx semantic-release --branches michaelpieper/semantic-release-fix -p "['@semantic-release/commit-analyzer', '@semantic-release/release-notes-generator', '@semantic-release/npm']" --dry-run --no-ci
+              npx semantic-release --branches michaelpieper/semantic-release-fix -p "@semantic-release/commit-analyzer,@semantic-release/release-notes-generator,@semantic-release/npm" --dry-run --no-ci
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
               echo $DEPLOY_KEY | base64 -d > /tmp/deploy_key
               chmod 600 /tmp/deploy_key
               ssh-add /tmp/deploy_key </dev/null
-              npx semantic-release --branches michaelpieper/semantic-release-fix --dry-run --no-ci
+              npx semantic-release --branches michaelpieper/semantic-release-fix -p "['@semantic-release/commit-analyzer', '@semantic-release/release-notes-generator', '@semantic-release/npm']" --dry-run --no-ci
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
               echo $DEPLOY_KEY | base64 -d > /tmp/deploy_key
               chmod 600 /tmp/deploy_key
               ssh-add /tmp/deploy_key </dev/null
-              npx semantic-release
+              npx semantic-release --branches main --dry-run
 
 
 workflows:
@@ -79,9 +79,9 @@ workflows:
       - msg_check
       - terraform_docs
   release:
-    when: 
-      condition:
-        equal: [ main, << pipeline.git.branch >> ]
+    # when: 
+    #   condition:
+    #     equal: [ main, << pipeline.git.branch >> ]
     jobs:
       - version_bump
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
               echo $DEPLOY_KEY | base64 -d > /tmp/deploy_key
               chmod 600 /tmp/deploy_key
               ssh-add /tmp/deploy_key </dev/null
-              npx semantic-release --branches michaelpieper/semantic-release-fix -p "@semantic-release/commit-analyzer,@semantic-release/release-notes-generator,@semantic-release/npm" --dry-run --no-ci
+              npx semantic-release --branches michaelpieper/semantic-release-fix -p "@semantic-release/commit-analyzer,@semantic-release/release-notes-generator" --dry-run --no-ci
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
               echo $DEPLOY_KEY | base64 -d > /tmp/deploy_key
               chmod 600 /tmp/deploy_key
               ssh-add /tmp/deploy_key </dev/null
-              npx semantic-release --branches michaelpieper/semantic-release-fix -p "@semantic-release/commit-analyzer,@semantic-release/release-notes-generator" --dry-run --no-ci
+              npx semantic-release
 
 
 workflows:
@@ -84,5 +84,3 @@ workflows:
     #     equal: [ main, << pipeline.git.branch >> ]
     jobs:
       - version_bump
-
-  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
               echo $DEPLOY_KEY | base64 -d > /tmp/deploy_key
               chmod 600 /tmp/deploy_key
               ssh-add /tmp/deploy_key </dev/null
-              npx semantic-release --branches michaelpieper/semantic-release-fix --dry-run
+              npx semantic-release --branches michaelpieper/semantic-release-fix --dry-run --no-ci
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,8 +79,8 @@ workflows:
       - msg_check
       - terraform_docs
   release:
-    # when: 
-    #   condition:
-    #     equal: [ main, << pipeline.git.branch >> ]
+    when: 
+      condition:
+        equal: [ main, << pipeline.git.branch >> ]
     jobs:
       - version_bump

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
               echo $DEPLOY_KEY | base64 -d > /tmp/deploy_key
               chmod 600 /tmp/deploy_key
               ssh-add /tmp/deploy_key </dev/null
-              npx semantic-release --branches main --dry-run
+              npx semantic-release --branches michaelpieper/semantic-release-fix --dry-run
 
 
 workflows:

--- a/.releaserc
+++ b/.releaserc
@@ -2,8 +2,6 @@ branches: ["main"]
 tagFormat: ${version}
 plugins:
   [
-
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/github",
   ]


### PR DESCRIPTION

## Description
Currently only ssh auth has been provided to CI to push new version tags. The github release mechanism will be disabled, removing the need for a token.


## Issue or Ticket
<!--- There should be an issue (github issue) or Jira ticket for this work -->

<!--- Please link to the issue here: -->
https://fullstory.atlassian.net/browse/INFRA-6583

<!-- Comment this out if you'd like to include more information for an easier review
## Additional Info
 -->


## Checklist before submitting PR for review
- [ ] I have tested these changes with the included tfvars
- [ ] This change requires a doc update, and I've included it
- [ ] My code follows the style guidelines of this project
- [ ] I have ensured my code is commented and any new terraform variables have proper descriptions
