### PR TITLE
Add optional variable to define cloudfront origin request policy name

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@ script configuration can be found in [this KB article](https://help.fullstory.co
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_acm_certificate_arn"></a> [acm\_certificate\_arn](#input\_acm\_certificate\_arn) | (optional) The ARN of the ACM certificate to be used for the relay. If omitted, a value for `route53_zone_name` must be provided. Defaults to null. | `string` | `null` | no |
-| <a name="input_relay_fqdn"></a> [relay\_fqdn](#input\_relay\_fqdn) | The fully qualified domain name for the relay. Example: `fsrelay.your-company.com`. | `string` | n/a | yes |
-| <a name="input_route53_zone_name"></a> [route53\_zone\_name](#input\_route53\_zone\_name) | (optional) The Route 53 zone name for placing the DNS CNAME record. If omitted, a value for `acm_certificate_arn` must be provided. Defaults to null. | `string` | `null` | no |
-| <a name="input_target_fqdn"></a> [target\_fqdn](#input\_target\_fqdn) | (optional) The fully qualified domain name that the relay targets. Defaults to `fullstory.com`. | `string` | `"fullstory.com"` | no |
+| Name                                                                                                                                                      | Description                                                                                                                                                                                                                                                         | Type | Default | Required |
+|-----------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------|---------|:--------:|
+| <a name="input_acm_certificate_arn"></a> [acm\_certificate\_arn](#input\_acm\_certificate\_arn)                                                           | (optional) The ARN of the ACM certificate to be used for the relay. If omitted, a value for `route53_zone_name` must be provided. Defaults to null.                                                                                                                 | `string` | `null` | no |
+| <a name="input_relay_fqdn"></a> [relay\_fqdn](#input\_relay\_fqdn)                                                                                        | The fully qualified domain name for the relay. Example: `fsrelay.your-company.com`.                                                                                                                                                                                 | `string` | n/a | yes |
+| <a name="input_route53_zone_name"></a> [route53\_zone\_name](#input\_route53\_zone\_name)                                                                 | (optional) The Route 53 zone name for placing the DNS CNAME record. If omitted, a value for `acm_certificate_arn` must be provided. Defaults to null.                                                                                                               | `string` | `null` | no |
+| <a name="input_target_fqdn"></a> [target\_fqdn](#input\_target\_fqdn)                                                                                     | (optional) The fully qualified domain name that the relay targets. Defaults to `fullstory.com`.                                                                                                                                                                     | `string` | `"fullstory.com"` | no |
+| <a name="input_cloudfront_origin_request_policy_name"></a> [cloudfront\_origin\_request\_policy\_name](#input\_cloudfront\_origin\_request\_policy\_name) | (optional) A name to uniquely identify the cloudfront origin request policy for the relay. This is required to deploy multiple relay modules to the same AWS account, as such policies must be uniquely named. Defaults to `fullstory-relay-origin-request-policy`. | `string` | `"fullstory-relay-origin-request-policy"` | no |
 
 ## Outputs
 
@@ -36,7 +37,7 @@ script configuration can be found in [this KB article](https://help.fullstory.co
 
 ### With Route 53 Record Creation
 
-This module will automatically create the DNS records if a value for `route53_zone_name` is provided in reference to an existing Route 53 zone within hte same AWS account.
+This module will automatically create the DNS records if a value for `route53_zone_name` is provided in reference to an existing Route 53 zone within the same AWS account.
 
 ```hcl
 module "fullstory_relay" {

--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,8 @@ resource "aws_acm_certificate_validation" "fullstory_relay" {
 ######## CloudFront Resources ########
 
 resource "aws_cloudfront_origin_request_policy" "fullstory_relay" {
-  name    = "fullstory-relay-origin-request-policy"
+  name    = var.cloudfront_origin_request_policy_name
+
   comment = "FullStory Relay"
   headers_config {
     header_behavior = "allExcept"

--- a/variables.tf
+++ b/variables.tf
@@ -20,3 +20,9 @@ variable "acm_certificate_arn" {
   description = "(optional) The ARN of the ACM certificate to be used for the relay. If omitted, a value for `route53_zone_name` must be provided. Defaults to null."
   default     = null
 }
+
+variable "cloudfront_origin_request_policy_name" {
+  type        = string
+  description = "(optional) A name to uniquely identify the cloudfront origin request policy for the relay. This is required to deploy multiple relay modules to the same AWS account, as such policies must be uniquely named. Example: `fullstory-relay-origin-request-policy-production`."
+  default     = "fullstory-relay-origin-request-policy"
+}


### PR DESCRIPTION
## Description
Adding a new optional input parameter to specify the cloudfront origin request policy name. This enables users to deploy multiple fullstory relays to the same AWS account, because in the current state the only blocker is the static name of this policy. Attempting to deploy multiple fullstory relays to one account in the current version will result in failure to create this resource for all additional module instances.

There are no changes in behavior for existing consumers, as the input variable is optional and the default value is the same as the existing value.

Also a minor typo fix in README alongside the README change for new input variable.

## Issue or Ticket
https://github.com/fullstorydev/terraform-aws-fullstory-cloud-relay/issues/12 (I just created this)

## Additional Info
There are a few ways to solve this, but ultimately I think the simplest is to allow the user to explicitly define the name of this particular resource. There is only 1 resource which is blocking the deployment of multiple modules in 1 account, so it seems like overkill to create a generic parameter to ensure unique creation of all resources. That can always be made later if it is needed.

Technically the policy could be shared across module instances, but as far as I know it is best practice for terraform modules to be cleanly added/removed independently, and permissions resources in AWS are all free to my knowledge so creating a duplicate doesn't really matter.

I've tested this in my own setup and it seems to be a clean fully-backwards-compatible upgrade.

## Checklist before submitting PR for review
- [X] I have tested these changes with the included tfvars
- [X] This change requires a doc update, and I've included it
- [X] My code follows the style guidelines of this project
- [X] I have ensured my code is commented and any new terraform variables have proper descriptions
